### PR TITLE
Fix HAOS 17.3+ FATAL crash: Electron sandbox + non-root launch

### DIFF
--- a/oxwu/Dockerfile
+++ b/oxwu/Dockerfile
@@ -1,0 +1,29 @@
+FROM tsunglung/oxwu:1.0.5
+
+# === HAOS 17.3+ kernel namespace restriction workaround ===
+# Issue: After HAOS 17.3 (CVE-2026-31431 kernel patch),
+#        unprivileged user namespace clones are blocked.
+#        Chromium's namespace sandbox fails -> Electron FATAL.
+# Fix:   3 actions combined (any one alone is insufficient):
+#        1. Pre-extract AppImage at build time (bypass AppImage runtime that
+#           swallows --no-sandbox flag)
+#        2. Run as kasm-user (UID 1000) instead of root (bypass Electron's
+#           geteuid()==0 forced sandbox check)
+#        3. Pass --no-sandbox to AppRun (skip namespace sandbox attempt)
+
+WORKDIR /opt
+
+# 1. Extract AppImage so we can invoke AppRun directly
+RUN /Applications/oxwu-linux-x86_64.AppImage --appimage-extract && \
+    mv squashfs-root oxwu-extracted && \
+    chmod -R a+rX oxwu-extracted && \
+    rm -f /opt/oxwu-extracted/chrome-sandbox && \
+    chown -R kasm-user:root /opt/oxwu-extracted
+
+# 2. Disable original AppImage path (avoid any code path bypassing our patch)
+RUN mv /Applications/oxwu-linux-x86_64.AppImage \
+       /Applications/oxwu-linux-x86_64.AppImage.disabled
+
+# 3. Replace kasm's startup script with one that uses runuser + --no-sandbox
+COPY custom_startup.sh /dockerstartup/custom_startup.sh
+RUN chmod a+x /dockerstartup/custom_startup.sh

--- a/oxwu/config.yaml
+++ b/oxwu/config.yaml
@@ -1,10 +1,9 @@
 name: "OX Wake Up"
 description: "OX Wake up add-on!"
-version: "1.0.5"
+version: "1.0.6"
 codenotary: tsunglung@github.com
 description: Home Assistant Add-on for OXWU, the earthquake alert
 url: https://github.com/tsunglung/hassio-addon-oxwu
-image: tsunglung/oxwu
 slug: "oxwu"
 init: false
 arch:

--- a/oxwu/custom_startup.sh
+++ b/oxwu/custom_startup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OXWU startup script - patched for HAOS 17.3+ Electron sandbox compatibility
+# See: addon Dockerfile comments for full explanation
+set -e
+
+OXWU_ALERT_INTENSITY=$(grep oxwu_alert_intensity /data/options.json 2>/dev/null | cut -d: -f2 | tr -d '" ,')
+
+[ -f /app/notify.sh ] && chmod a+x /app/notify.sh
+[ -f /config/oxwu/notify.sh ] && chmod a+x /config/oxwu/notify.sh
+
+mkdir -p /home/kasm-user/.config/oxwu/
+[ -f /tmp/settings.json ] && cp /tmp/settings.json /home/kasm-user/.config/oxwu/settings.json
+[ -f /config/oxwu/settings.json ] && cp /config/oxwu/settings.json /home/kasm-user/.config/oxwu/settings.json
+[ "x$OXWU_ALERT_INTENSITY" != "x" ] && \
+    sed -i "s/\"alertIntensity\":.*/\"alertIntensity\": $OXWU_ALERT_INTENSITY,/g" \
+        /home/kasm-user/.config/oxwu/settings.json
+
+# Fix /home/kasm-user permissions (kasm-user needs to write SingletonLock, etc.)
+chown -R kasm-user:kasm-user /home/kasm-user 2>/dev/null
+chmod -R u+rwX /home/kasm-user 2>/dev/null
+
+# Run as kasm-user, invoke extracted AppRun directly with --no-sandbox
+exec runuser -u kasm-user -- env APPDIR=/opt/oxwu-extracted HERE=/opt/oxwu-extracted bash -c '
+cd /opt/oxwu-extracted
+exec ./AppRun --no-sandbox
+'


### PR DESCRIPTION
## 摘要

解決 HAOS 17.3+ 升級後 addon FATAL crash。Fixes #3。

將 addon 從 prebuilt image 改成 local build，加入三項修補：

1. Build 時預先解壓 AppImage 到 `/opt/oxwu-extracted/`（跳過 AppImage runtime 吞掉 `--no-sandbox` flag 的問題）
2. 改用 `kasm-user` (UID 1000) 而非 root 啟動 AppRun（跳過 Electron 的 `geteuid()==0` 強制 sandbox 檢查）
3. 直接呼叫 extracted AppRun 帶 `--no-sandbox` flag

**任何一招少做都 FATAL，三招同時做才會起來。**

## 變更檔案

| 檔案 | 變更 |
|---|---|
| `oxwu/config.yaml` | 移除 `image: tsunglung/oxwu` 一行（讓 supervisor build local），version 1.0.5 → 1.0.6 |
| `oxwu/Dockerfile`（新增） | `FROM tsunglung/oxwu:1.0.5` + 預解 AppImage + chown + COPY startup script |
| `oxwu/custom_startup.sh`（新增） | 覆寫 kasm 啟動腳本，用 `runuser -u kasm-user` 拉起 AppRun |

## 驗證

部署在 HAOS 17.3 + Core 2026.5.2 上：

- ✅ Main oxwu + 7 個 worker child（zygote ×2、gpu、NetworkService、renderer、audio）全部活著，全部跑 `kasm-user`
- ✅ 全部 child process 都帶 `--no-sandbox` flag（從 `ps -eo cmd` 觀察）
- ✅ MQTT 連線 ESTABLISHED 到 `mqtt4.earthquake.tw:8883`
- ✅ HAOS 重開機後 `boot=auto` 自動啟動

`netstat` 證據：
```
ESTAB 0 0  <local>:60492  →  172.104.99.22:8883
```

## 已知的 cosmetic 問題

Log 中仍會出現：
```
[FATAL:electron_main_delegate.cc(299)] Running as root without --no-sandbox is not supported.
```

這是 Chromium 某個短暫存活的 helper child crash（沒有 PID prefix，代表是 fresh process 在 logger init 前 FATAL）。但**main process 與 MQTT subscriber 持續運作**，不影響功能。

## 向下相容

HAOS < 17.3 的使用者套用本 PR 不會壞：
- `runuser` 在任何 Linux 都能用
- `--no-sandbox` 在沒 kernel 限制的情況下只是 disable sandbox（OXWU 不渲染任意網頁，風險可控）
- 唯一影響：build time 增加約 1-2 分鐘（image extract）

## 已考慮過的替代方案

| 方案 | 為何不行 |
|---|---|
| 只加 `--no-sandbox` flag、保留 root | Electron child process 在 root + namespace sandbox blocked 下仍 FATAL |
| 改 HAOS sysctl `kernel.unprivileged_userns_clone=1` | 弱化 CVE-2026-31431 patch，且 HAOS 升級會還原 |
| 等 OXWU 作者出新版 image | 此 repo 一年沒更新；OXWU 本體 closed source |

## 參考連結

- `crbug.com/638180` — Chromium 對 root 跑 sandbox 的硬性檢查
- CVE-2026-31431 — HAOS 17.3 kernel patch
